### PR TITLE
fix: target group attachment for multiple ec2 instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -278,7 +278,7 @@ resource "aws_lb_target_group" "main" {
 ## For attaching resources with Elastic Load Balancer (ELB), see the aws_elb_attachment resource.
 ##-----------------------------------------------------------------------------
 resource "aws_lb_target_group_attachment" "attachment" {
-  count = var.enable && var.with_target_group && var.load_balancer_type == "application" ? length(var.https_listeners) : 0
+  count = var.enable && var.with_target_group && var.load_balancer_type == "application" ? length(var.target_id) : 0
 
   target_group_arn = element(aws_lb_target_group.main[*].arn, count.index)
   target_id        = element(var.target_id, count.index)


### PR DESCRIPTION
## what
- Fix `aws_lb_target_group_attachment` resource to attach multiple EC2 instance by providing instance id (i-0a1b2c3d4e5f)

## why
- With previously used condition `count = (xyz) ? length(var.https_listeners) : 0` only first ec2 instance was being registered in ALB TargetGroup even when passing multiple ec2 arns in `target_id = ["arn-1","arn-2","arn-3"]` 