### PR TITLE
feat: create A record for dns of alb and specified domain/subdomain name

### DIFF
--- a/_example/alb/example.tf
+++ b/_example/alb/example.tf
@@ -139,6 +139,8 @@ module "alb" {
   https_port                 = 443
   listener_type              = "forward"
   target_group_port          = 80
+  dns_record_name            = "example.clouddrove.ca"
+  hosted_zone_id             = "Z06XXXXXXXXXXXXXAL4"
 
   http_tcp_listeners = [
     {

--- a/main.tf
+++ b/main.tf
@@ -790,3 +790,19 @@ resource "aws_lb_listener_certificate" "https_listener" {
   listener_arn    = aws_lb_listener.https[var.extra_ssl_certs[count.index]["https_listener_index"]].arn
   certificate_arn = var.extra_ssl_certs[count.index]["certificate_arn"]
 }
+
+##----------------------------------------------------------------------------------
+## A Route 53 record to map ELB DNS with specified domain/subdomain.
+##----------------------------------------------------------------------------------
+resource "aws_route53_record" "default" {
+  count = var.enable && var.dns_record_name != null ? 1 : 0
+
+  zone_id = var.hosted_zone_id
+  name    = var.dns_record_name
+  type    = var.dns_record_type
+  alias {
+    name                   = join("", aws_lb.main[*].dns_name)
+    zone_id                = join("", aws_lb.main[*].zone_id)
+    evaluate_target_health = var.evaluate_target_health
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -450,3 +450,27 @@ variable "ipv6_cidr_blocks" {
   default     = ["::/0"]
   description = "Enable to create egress rule"
 }
+
+variable "hosted_zone_id" {
+  type        = string
+  default     = ""
+  description = "(Required) The ID of the hosted zone to contain this record."
+}
+
+variable "dns_record_name" {
+  type        = string
+  default     = null
+  description = "(Required) The name of the record. Example: `foo.bar.com` "
+}
+
+variable "dns_record_type" {
+  type        = string
+  default     = "A"
+  description = "(Required) The record type. Valid values are A, AAAA, CAA, CNAME, DS, MX, NAPTR, NS, PTR, SOA, SPF, SRV and TXT."
+}
+
+variable "evaluate_target_health" {
+  type        = bool
+  default     = false
+  description = "(Required) Set to true if you want Route 53 to determine whether to respond to DNS queries using this resource record set by checking the health of the resource record set. Some resources have special requirements, [see related part of documentation.](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values.html#rrsets-values-alias-evaluate-target-health)"
+}


### PR DESCRIPTION
## what
- A resource `aws_route53_record` to create A (or any) type of Record in mentioned Route53 Hosted-Zone.

## why
- To automate the process of Route53 record creation with alb DNS.