### PR TITLE
chore(terraform): rollout Terraform 1.15.0

### DIFF
--- a/_example/alb/versions.tf
+++ b/_example/alb/versions.tf
@@ -1,6 +1,6 @@
 # Terraform version
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = ">= 1.15.0.0"
 
   required_providers {
     aws = {

--- a/_example/clb/versions.tf
+++ b/_example/clb/versions.tf
@@ -1,6 +1,6 @@
 # Terraform version
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = ">= 1.15.0.0"
 
   required_providers {
     aws = {

--- a/_example/nlb/versions.tf
+++ b/_example/nlb/versions.tf
@@ -1,6 +1,6 @@
 # Terraform version
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = ">= 1.15.0.0"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 # Terraform version
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = ">= 1.15.0.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Summary
- bump Terraform `required_version` constraints to **1.15.0** where defined
- bump CI Terraform pinning (`setup-terraform` inputs) to **1.15.0**
- keep existing workflow structure/reusable workflow usage unchanged

## Validation
- existing CI will run on this PR
- auto-merge is enabled and will complete once required checks/reviews pass